### PR TITLE
Strings cannot contain newlines

### DIFF
--- a/pyjexl/parser.py
+++ b/pyjexl/parser.py
@@ -65,8 +65,8 @@ def jexl_grammar(jexl_config):
         relative_identifier = "." identifier
 
         boolean = "true" / "false"
-        string = ~"\"[^\"\\\\]*(?:\\\\.[^\"\\\\]*)*\""is /
-                 ~"'[^'\\\\]*(?:\\\\.[^'\\\\]*)*'"is
+        string = ~"\"[^\"\\\\\\n]*(?:\\\\.[^\"\\\\\\n]*)*\""is /
+                 ~"'[^'\\\\\\n]*(?:\\\\.[^'\\\\\\n]*)*'"is
         numeric = "-"? number ("." number)?
 
         number = ~r"[0-9]+"

--- a/tests/test_jexl.py
+++ b/tests/test_jexl.py
@@ -114,6 +114,9 @@ def test_validate():
     errors = list(jexl.validate('1+'))
     assert errors == ['Could not parse expression: 1+']
 
+    errors = list(jexl.validate('"\n"'))
+    assert errors == ['Could not parse expression: "\n"']
+
 
 def test_validate_simple_equality():
     jexl = JEXL()


### PR DESCRIPTION
Trying to include one causes a VisitationError (see
e.g. https://github.com/mozilla/normandy/issues/1059).

It may be worth catching VisitationErrors in validate(), but at least
make explicit that strings cannot contain literal newlines.