### PR TITLE
Install pytest for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /build
 /dist
 /.tox
+.eggs
+.pytest_cache

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,6 @@ universal=1
 [flake8]
 max-line-length=99
 ignore=W503
+
+[aliases]
+test=pytest

--- a/setup.py
+++ b/setup.py
@@ -66,11 +66,7 @@ setup(
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=['parsimonious'],
 
-    # List additional groups of dependencies here (e.g. development
-    # dependencies). You can install these using the following syntax,
-    # for example:
-    # $ pip install -e .[dev,test]
-    extras_require={
-        'test': ['pytest'],
-    },
+    # So that you can run `python setup.py test`.
+    tests_require=['pytest'],
+    setup_requires=['pytest-runner'],
 )


### PR DESCRIPTION
Now you can run `python setup.py test`

Note, if you have a fresh clone and run `pip install -e .` it will NOT install all the test requirements.

```
▶ pip install -e .
Obtaining file:///Users/peterbe/dev/PYTHON/pyjexl
Collecting parsimonious (from pyjexl==0.2.2)
Collecting six>=1.9.0 (from parsimonious->pyjexl==0.2.2)
  Using cached six-1.11.0-py2.py3-none-any.whl
Installing collected packages: six, parsimonious, pyjexl
  Running setup.py develop for pyjexl
Successfully installed parsimonious-0.8.0 pyjexl six-1.11.0
(pyjexl)
▶ pip freeze
parsimonious==0.8.0
-e git+https://github.com/mozilla/pyjexl.git@cd4f1b76af37ad799a159a748e7de25a1d0e0163#egg=pyjexl
six==1.11.0
```

So, it won't drag in `pytest` and those guys if someone does `pip install pyjexl` in another project. 