### PR TITLE
README: Fix Jexl owner and link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 A Python-based JEXL parser and evaluator.
 
 **NOTE:** This library handles the JEXL from
-[TechnologyAdvice's JEXL library][jexl]. It does **NOT** handle the
+[TomFrost's JEXL library][jexl]. It does **NOT** handle the
 similarly-named Apache Commons JEXL language.
 
-[jexl]: https://github.com/TechnologyAdvice/Jexl
+[jexl]: https://github.com/TomFrost/Jexl
 
 ## Limitations and Differences from JEXL
 


### PR DESCRIPTION
I'm flattered that this project exists! I'm the original author of Jexl. TechnologyAdvice has released their rights to Jexl, and transferred ownership and maintenance of the project to me. This is just a quick PR to reflect the new link.

Thanks!