### PR TITLE
Add shortcut ability for logic operators

### DIFF
--- a/pyjexl/evaluator.py
+++ b/pyjexl/evaluator.py
@@ -38,13 +38,13 @@ class Evaluator(object):
         return method(expression, context)
 
     def visit_BinaryExpression(self, exp, context):
-        left = self.evaluate(exp.left, context)
-        right = self.evaluate(exp.right, context)
-        return exp.operator.evaluate(left, right)
+        return exp.operator.do_evaluate(
+            lambda: self.evaluate(exp.left, context),
+            lambda: self.evaluate(exp.right, context)
+        )
 
     def visit_UnaryExpression(self, exp, context):
-        right = self.evaluate(exp.right, context)
-        return exp.operator.evaluate(right)
+        return exp.operator.do_evaluate(lambda: self.evaluate(exp.right, context))
 
     def visit_Literal(self, literal, context):
         return literal.value

--- a/pyjexl/operators.py
+++ b/pyjexl/operators.py
@@ -2,12 +2,25 @@ import operator
 
 
 class Operator(object):
-    __slots__ = ('symbol', 'precedence', 'evaluate')
+    __slots__ = ('symbol', 'precedence', 'evaluate', '_evaluate_lazy')
 
-    def __init__(self, symbol, precedence, evaluate):
+    def __init__(self, symbol, precedence, evaluate, evaluate_lazy=False):
+        """Operator definition.
+
+        If evaluate_lazy is set to True, the `evaluate()` method will receive
+        it's parameters as a lambda expression that needs to be called to
+        receive the value of the expression. Otherwise, the values will
+        already be evaluated.
+        """
         self.symbol = symbol
         self.precedence = precedence
         self.evaluate = evaluate
+        self._evaluate_lazy = evaluate_lazy
+
+    def do_evaluate(self, *args):
+        if self._evaluate_lazy:
+            return self.evaluate(*args)
+        return self.evaluate(*(arg() for arg in args))
 
     def __repr__(self):
         return 'Operator({})'.format(repr(self.symbol))
@@ -27,8 +40,8 @@ default_binary_operators = {
     '>': Operator('>', 20, operator.gt),
     '<=': Operator('<=', 20, operator.le),
     '<': Operator('<', 20, operator.lt),
-    '&&': Operator('&&', 10, lambda a, b: a and b),
-    '||': Operator('||', 10, lambda a, b: a or b),
+    '&&': Operator('&&', 10, lambda a, b: a() and b(), evaluate_lazy=True),
+    '||': Operator('||', 10, lambda a, b: a() or b(), evaluate_lazy=True),
     'in': Operator('in', 20, lambda a, b: a in b),
 }
 

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -176,3 +176,17 @@ def test_conditional_expression():
 def test_arbitrary_whitespace():
     result = DefaultEvaluator().evaluate(tree('(\t2\n+\n3) *\n4\n\r\n'))
     assert result == 20
+
+
+@pytest.mark.parametrize('expression,expect_result,expect_fail', [
+    ('true || 1/0', True, False),
+    ('true && 1/0', None, True),
+    ('false || 1/0', None, True),
+    ('false && 1/0', False, False),
+])
+def test_logic_shortcuts(expression, expect_result, expect_fail):
+    if expect_fail:
+        with pytest.raises(Exception):
+            DefaultEvaluator().evaluate(tree(expression))
+    else:
+        assert expect_result == DefaultEvaluator().evaluate(tree(expression))


### PR DESCRIPTION
In most languages (and now also in TomFrost's JEXL), logic operators
implement shortcuts: For example when evaluating `(A && B)`, the
expression `B` will not be evaluated when `A` is `False`. Similarly, in
`A || B`, the right operand will be ignored if `A` evaluates to `True`.

This extends our operators to support shortcut / lazy evaluation.
Operators now have a flag `evaluate_lazy` to denote this, which can be
used to implement custom operators as well.