### PR TITLE
fix: import from collections.abc

### DIFF
--- a/pyjexl/evaluator.py
+++ b/pyjexl/evaluator.py
@@ -1,4 +1,4 @@
-from collections import MutableMapping
+from collections.abc import MutableMapping
 from pyjexl.exceptions import MissingTransformError
 
 

--- a/pyjexl/jexl.py
+++ b/pyjexl/jexl.py
@@ -1,5 +1,5 @@
 from builtins import str
-from collections import namedtuple
+from collections.abc import namedtuple
 from functools import wraps
 
 from parsimonious.exceptions import ParseError as ParsimoniousParseError


### PR DESCRIPTION
The collections module is deprecated and will be removed in python 3.9