### PR TITLE
Collection of fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ shared:
           command: |
             python -m venv venv || virtualenv venv
             . venv/bin/activate
+            pip install -U pip
             pip install -r requirements.txt
 
       - save_cache:
@@ -40,6 +41,10 @@ workflows:
   version: 2
   test_upload:
     jobs:
+      - test-3.10:
+          filters:
+            tags:
+              only: /.*/
       - test-3.6:
           filters:
             tags:
@@ -50,6 +55,7 @@ workflows:
               only: /.*/
       - upload:
           requires:
+            - test-3.10
             - test-3.6
             - test-2.7
           filters:
@@ -104,6 +110,11 @@ jobs:
           command: |
             . venv/bin/activate
             twine upload dist/*
+
+  test-3.10:
+    <<: *test-template
+    docker:
+      - image: circleci/python:3.10-node
 
   test-3.6:
     <<: *test-template

--- a/pyjexl/evaluator.py
+++ b/pyjexl/evaluator.py
@@ -1,4 +1,11 @@
-from collections.abc import MutableMapping
+try:
+    from collections.abc import MutableMapping
+except ImportError:
+    # Python 2.7 compat
+    # TODO: Decide if we stop supporting 2.7
+    # as it's been EOL for a while now
+    from collections import MutableMapping
+
 from pyjexl.exceptions import MissingTransformError
 
 

--- a/pyjexl/jexl.py
+++ b/pyjexl/jexl.py
@@ -1,5 +1,5 @@
 from builtins import str
-from collections.abc import namedtuple
+from collections import namedtuple
 from functools import wraps
 
 from parsimonious.exceptions import ParseError as ParsimoniousParseError

--- a/tests/test_jexl.py
+++ b/tests/test_jexl.py
@@ -6,7 +6,7 @@ from pyjexl.exceptions import MissingTransformError, ParseError
 from pyjexl.jexl import JEXL
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def jexl():
     """Return an instance of the JEXL class. Useful when tests are
     repeated with hypothesis since only one instance of JEXL is created


### PR DESCRIPTION
Fix a couple of issues with the current test/build env:

* Restore Python 2.7 compatibility (Fix collections.abc import)
* Get rid of hypothesis warning
* Run tests with python 3.10

Note: This contains, ans superesedes, #26 